### PR TITLE
add postgres as default password in .env

### DIFF
--- a/packages/benchmarks/.env
+++ b/packages/benchmarks/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/orchid-orm-benchmarks
+DATABASE_URL=postgres://postgres:password@localhost:5432/orchid-orm-benchmarks

--- a/packages/benchmarks/.env
+++ b/packages/benchmarks/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://postgres:@localhost:5432/orchid-orm-benchmarks
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/orchid-orm-benchmarks


### PR DESCRIPTION
many people use postgres as their default password and for those who don't they will see a nicer error: "Permission denied to create database."